### PR TITLE
Silvermoon Alchemy + Improvements to the base addon

### DIFF
--- a/PrintQuests.lua
+++ b/PrintQuests.lua
@@ -1,7 +1,9 @@
 PrintQuests = {}
 local frame = CreateFrame("Frame")
 
+frame:RegisterEvent("ADDON_LOADED")
 frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+frame:RegisterEvent("QUEST_DATA_LOAD_RESULT")
 frame:RegisterEvent("CRITERIA_UPDATE")
 frame:RegisterEvent("QUEST_ACCEPTED")
 frame:RegisterEvent("QUEST_TURNED_IN")
@@ -9,7 +11,18 @@ frame:RegisterEvent("QUEST_REMOVED")
 frame:RegisterEvent("QUEST_WATCH_UPDATE")
 frame:RegisterEvent("QUEST_LOG_UPDATE")
 
-local function PrintQuest(printType, questID)
+local isReady = false
+
+local function AddTrackingMessage(msg)
+    if Grail and Grail.GDE then
+        Grail:_AddTrackingMessage(msg)
+    end
+end
+
+-- Queue: questID -> printType (only one printType per questID at a time)
+local printQueue = {}
+
+local function ActuallyPrintQuest(printType, questID)
     local questName = C_QuestLog.GetTitleForQuestID(questID)
     
     -- dont print quests which are spammed since 12.0.0
@@ -43,32 +56,55 @@ local function PrintQuest(printType, questID)
     end
     
     if questName then
-        print("Quest ".. printType ..": |cFF00FF00" .. questName .. "|r (ID: " .. questID .. ")")
+        print("(PQ) Quest ".. printType ..": |cFF00FF00" .. questName .. "|r (ID: " .. questID .. ")")
+        AddTrackingMessage("(PQ) Quest ".. printType ..": |" .. questName .. "|r (ID: " .. questID .. ")")
+    elseif Grail and Grail.GDE and Grail:QuestName(questID) then
+        print("(PQ) Quest ".. printType ..": |cff91afGrail-TRACKING " .. Grail:QuestName(questID) .. "|r (ID: " .. questID .. ")")
+        AddTrackingMessage("(PQ) Quest ".. printType ..": |Grail-TRACKING " .. Grail:QuestName(questID) .. "|r: (ID: " .. questID .. ")")
     elseif PrintQuests.ConfidentlyNamedTrackingQuests[questID] then
-        print("Quest ".. printType ..": |cFF00FF00TRACKING " .. PrintQuests.ConfidentlyNamedTrackingQuests[questID] .. "|r (ID: " .. questID .. ")")
+        print("(PQ) Quest ".. printType ..": |cFF00FF00TRACKING " .. PrintQuests.ConfidentlyNamedTrackingQuests[questID] .. "|r (ID: " .. questID .. ")")
+        AddTrackingMessage("(PQ) Quest ".. printType ..": |TRACKING " .. PrintQuests.ConfidentlyNamedTrackingQuests[questID] .. "|r: (ID: " .. questID .. ")")
     elseif PrintQuests.UnsurelyNamedTrackingQuests[questID] then
-        print("Quest ".. printType ..": |cFFFFFF00TRACKING " .. PrintQuests.UnsurelyNamedTrackingQuests[questID] .. "|r (ID: " .. questID .. ")")
+        print("(PQ) Quest ".. printType ..": |cFFFFFF00TRACKING " .. PrintQuests.UnsurelyNamedTrackingQuests[questID] .. "|r (ID: " .. questID .. ")")
+        AddTrackingMessage("(PQ) Quest ".. printType ..": TRACKING " .. PrintQuests.UnsurelyNamedTrackingQuests[questID] .. "|r: (ID: " .. questID .. ")")
     else
-        print("Quest ".. printType .." |cFFFF0000(Tracking)|r: (ID: " .. questID .. ")")
+        print("(PQ) Quest ".. printType .." |cFFFF0000(Tracking)|r: (ID: " .. questID .. ")")
+        AddTrackingMessage("(PQ) Quest ".. printType ..": |(Tracking)|r: (ID: " .. questID .. ")")
     end
+end
+
+local function FlushPrintQueue(questID)
+    local printType = printQueue[questID]
+    if not printType then return end
+    printQueue[questID] = nil
+    ActuallyPrintQuest(printType, questID)
+end
+
+local function PrintQuest(printType, questID)
+    printQueue[questID] = printType
+    C_QuestLog.RequestLoadQuestByID(questID)
+    -- Timeout fallback after 20 seconds
+    C_Timer.After(20, function()
+        FlushPrintQueue(questID)
+    end)
 end
 
 local completedQuests = {}
 
-local function QueryCompletedQuests(isInitialLogin)
+local function QueryCompletedQuests(suppressOutput)
     local currentCompletedQuests = {}
     local completedQuestIDs = C_QuestLog.GetAllCompletedQuestIDs()
     if completedQuestIDs then
         for _, questID in ipairs(completedQuestIDs) do
             currentCompletedQuests[questID] = true
-            if not isInitialLogin then
+            if not suppressOutput then
                 if not completedQuests[questID] then
                     PrintQuest("rewarded", questID)
                 end
             end
         end
     end
-    if not isInitialLogin then
+    if not suppressOutput then
         for questID, _ in pairs(completedQuests) do
             if not currentCompletedQuests[questID] then
                 PrintQuest("reverted", questID)
@@ -76,24 +112,38 @@ local function QueryCompletedQuests(isInitialLogin)
         end
     end
     completedQuests = currentCompletedQuests
+
+    PrintQuestsSavedData = PrintQuestsSavedData or {}
+    PrintQuestsSavedData.completedQuests = completedQuests
+    PrintQuestsSavedData.initialized = true
 end
 
 local lastQueryTime = 0
-local QUERY_THROTTLE_INTERVAL = 0.25 -- in seconds
+local QUERY_THROTTLE_INTERVAL = 0.25
 local function ThrottledQueryCompletedQuests()
+    if not isReady then return end
     local currentTime = GetTime()
     if currentTime - lastQueryTime > QUERY_THROTTLE_INTERVAL then
-        QueryCompletedQuests()
+        QueryCompletedQuests(false)
         lastQueryTime = currentTime
     end
 end
 
 frame:SetScript("OnEvent", function(self, event, ...)
-    if event == "PLAYER_ENTERING_WORLD" then
-        local isInitialLogin, isReloadingUi = ...
-        if isInitialLogin then
-            QueryCompletedQuests(isInitialLogin)
+    if event == "ADDON_LOADED" then
+        local addonName = ...
+        if addonName == "PrintQuests" then
+            if PrintQuestsSavedData and PrintQuestsSavedData.completedQuests then
+                completedQuests = PrintQuestsSavedData.completedQuests
+            end
         end
+    elseif event == "PLAYER_ENTERING_WORLD" then
+        local isFirstEverRun = not (PrintQuestsSavedData and PrintQuestsSavedData.initialized)
+        QueryCompletedQuests(isFirstEverRun)
+        isReady = true
+    elseif event == "QUEST_DATA_LOAD_RESULT" then
+        local questID, success = ...
+        FlushPrintQueue(questID)
     elseif event == "CRITERIA_UPDATE" or event == "QUEST_LOG_UPDATE" then
         ThrottledQueryCompletedQuests()
     elseif event == "QUEST_ACCEPTED" then

--- a/PrintQuests.toc
+++ b/PrintQuests.toc
@@ -5,6 +5,8 @@
 ## Notes: Prints quests in chat
 ## Author: ModoX
 ## IconTexture: Interface\ICONS\Ability_druid_maul
+## OptionalDeps: Grail
+## SavedVariablesPerCharacter: PrintQuestsSavedData
 
 PrintQuests.lua
 TrackingQuests.lua

--- a/TrackingQuests.lua
+++ b/TrackingQuests.lua
@@ -2104,6 +2104,7 @@ PrintQuests.ConfidentlyNamedTrackingQuests = {
     [91060] = "Stay a while and listen: Loa Speaker Kinduru on quest The Path of the Amani (86653)",
     [92125] = "Stay a while and listen: Zul'jarra on quest Shadebasin Watch (86657)",
     [92108] = "Stay a while and listen: Zul'jan on quest Broken Bridges (91062)",
+    [94627] = "Zul'Aman: Interacted with Tablet of Akil'zon (53.12/82.12)",
     [94628] = "Zul'Aman: Interacted with Tablet of Halazzi",
     [94631] = "Zul'Aman: Interacted with Tablet of Jan'alai",
     [94673] = "Zul'Aman: Interacted with Tablet of Kulzi",

--- a/TrackingQuests.lua
+++ b/TrackingQuests.lua
@@ -2090,6 +2090,9 @@ PrintQuests.ConfidentlyNamedTrackingQuests = {
 
     -- -----------------------------------------------------------------------------------------------------------------------
     -- Silvermoon
+    [89111] = "Silvermoon Treasure: Alchemy: Vial of Eversong Oddities", -- item:238532 , increases MN alchemy knowledge by 3
+    [89115] = "Silvermoon Treasure: Alchemy: Freshly Plucked Peacebloom", -- item:238536 , increases MN alchemy knowledge by 3
+    [89117] = "Silvermoon Treasure: Alchemy: Pristine Potion", -- item:238538 , increases MN alchemy knowledge by 3
     [89079] = "Silvermoon Treasure: Tailoring: A Really Nice Curtain", -- item:238613 , increases MN tailoring knowledge by 3
     [89080] = "Silvermoon Treasure: Tailoring: Sin'dorei Outfitter's Ruler", -- item:238614 , iocreases MN tailoring knowledge by 3
     [89084] = "Silvermoon Treasure: Tailoring: Particularly Enchanting Tablecloth", -- item:238618 , iocreases MN tailoring knowledge by 3


### PR DESCRIPTION
- add Silvermoon Alchemy items
- add (PQ) as Prefix to the output to make it stand out from other addons
- use RequestLoadQuestByID to fill the questname cache if possible
- optionally Log tracking quests to Grail if installed
- use Saved Variables to prevent repeatedly printing the same quests on login